### PR TITLE
Add Terraform configuration to deploy Azure resource group

### DIFF
--- a/infra/main.tf
+++ b/infra/main.tf
@@ -2,6 +2,15 @@ provider "azurerm" {
   features {}
 }
 
+terraform {
+  backend "azurerm" {
+    resource_group_name  = "terrateam-demo-state-rg" # Replace with your resource group name
+    storage_account_name = "terrateamteststate"      # Replace with your storage account name
+    container_name       = "terrateam-state"     # Replace with your container name
+    key                  = "terraform.tfstate"       # Path to the state file in the container
+  }
+}
+
 resource "azurerm_resource_group" "example" {
   name     = var.resource_group_name
   location = var.resource_group_location

--- a/infra/main.tf
+++ b/infra/main.tf
@@ -1,0 +1,8 @@
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "example" {
+  name     = var.resource_group_name
+  location = var.resource_group_location
+}

--- a/infra/outputs.tf
+++ b/infra/outputs.tf
@@ -1,0 +1,4 @@
+output "resource_group_id" {
+  description = "The ID of the resource group"
+  value       = azurerm_resource_group.example.id
+}

--- a/infra/provider.tf
+++ b/infra/provider.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = "~> 2.0"
+    }
+  }
+
+  required_version = ">= 0.12"
+}

--- a/infra/terraform.tfvars
+++ b/infra/terraform.tfvars
@@ -1,0 +1,2 @@
+resource_group_name = "example-resources"
+resource_group_location = "West US"

--- a/infra/variables.tf
+++ b/infra/variables.tf
@@ -1,0 +1,9 @@
+variable "resource_group_name" {
+  description = "The name of the resource group"
+  type        = string
+}
+
+variable "resource_group_location" {
+  description = "The location of the resource group"
+  type        = string
+}


### PR DESCRIPTION
Add Terraform configuration files to deploy a resource group to Microsoft Azure.

* **Main Configuration**: Add `infra/main.tf` to define the `azurerm` provider and a resource group with name and location variables.
* **Variables**: Add `infra/variables.tf` to define input variables for the resource group name and location.
* **Outputs**: Add `infra/outputs.tf` to define an output value for the resource group ID.
* **Default Values**: Add `infra/terraform.tfvars` to provide default values for the resource group name and location.
* **Provider Declaration**: Add `infra/provider.tf` to declare the required provider and Terraform version.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/pazdedav/terrateam-test/pull/1?shareId=2f9bfbc1-2074-46b0-8830-9586326b1753).